### PR TITLE
Workaround for https://crbug.com/765661: unreadable depth stream.

### DIFF
--- a/depth-camera.js
+++ b/depth-camera.js
@@ -60,7 +60,7 @@ DepthCamera.getDepthStream = async function () {
             audio: false,
             video: {
                 deviceId: {exact: track.getSettings().deviceId},
-                frameRate: {max: 60}
+                frameRate: {ideal: 60}
             }
         }
         stream = await navigator.mediaDevices.getUserMedia(constraints);


### PR DESCRIPTION
The change is related to difference in capture size, format and frame rate
prioritization: instead of unsupported 30Hz YUYV stream, constraining the
depth stream to 60Hz Y16 stream.